### PR TITLE
ci: gha workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,86 @@
+name: build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Buildx version (e.g. v0.8.1)'
+        required: true
+      dry-run:
+        description: 'Dry run'
+        required: true
+        type: boolean
+  push:
+    branches:
+      - 'main'
+      - 'v[0-9]*'
+  pull_request:
+
+env:
+  #REPO_SLUG: "docker/buildx-pkg" # FIXME: uncomment when moved to docker org and don't forget to update secrets
+  REPO_SLUG: "crazymax/buildx-packaging"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set Buildx version
+        if: github.event.inputs.version != ''
+        run: |
+          echo "BUILDX_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ env.REPO_SLUG }}
+          tags: |
+            type=raw,value=${{ env.BUILDX_VERSION }},enable=${{ github.event.inputs.version != '' }}
+            type=raw,value=${{ env.BUILDX_VERSION }}-${{ env.GITHUB_RUN_NUMBER }},enable=${{ github.event.inputs.version != '' }}
+            type=ref,event=branch
+            type=ref,event=pr
+          labels: |
+            github.buildx-packaging.run-id=${{ env.GITHUB_RUN_ID }}
+            github.buildx-packaging.run-number=${{ env.GITHUB_RUN_NUMBER }}
+          bake-target: meta-helper
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push image
+        uses: docker/bake-action@v1
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: pkg-cross
+          set: |
+            *.output=type=image,push=${{ github.event_name != 'pull_request' && github.event.inputs.dry-run != 'true' }}
+      -
+        name: Create Release
+        uses: softprops/action-gh-release@9729932bfb75c05ad1f6e3a729294e05abaa7001
+        if: github.event.inputs.version != '' && github.event.inputs.dry-run != 'true'
+        with:
+          name: ${{ env.BUILDX_VERSION }}-${{ env.GITHUB_RUN_NUMBER }}
+          tag_name: ${{ env.BUILDX_VERSION }}-${{ env.GITHUB_RUN_NUMBER }}
+          target_commitish: ${{ github.sha }}
+          body: |
+            * Tags pushed: [`${{ env.REPO_SLUG }}:${{ env.BUILDX_VERSION }}`, `${{ env.REPO_SLUG }}:${{ env.BUILDX_VERSION }}-${{ env.GITHUB_RUN_NUMBER }}`](https://hub.docker.com/r/${{ env.REPO_SLUG }})
+            * Buildx release: https://github.com/docker/buildx/releases/tag/${{ env.BUILDX_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow will publish the image that contains packages generated by the `pkg-cross` bake target.

For every push on the main branch the `main` tag will pushed (`docker/buildx-pkg:main`).

For releases, it's done via a manual trigger on the repo with two inputs. First one is the Buildx version that is required and the last one is `dry-run` if you want to test the workflow.

When a release is created, two tags will be pushed to Docker Hub. One is the version itself (e.g, `v0.8.1`) that will override `BUILDX_VERSION` in the bake definition.

The other one is also the version but with an unique suffix that is the [run number](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) for this workflow so we can release a version multiple time. For example if we need to create a new package for `debian12` but no new buildx version has been released yet. Here is what it would look like if we release `v0.8.1`:

* `docker/buildx-pkg:v0.8.1`
* `docker/buildx-pkg:v0.8.1-123`

In addition a git tag and GitHub Release will be created that is the version followed by its run number. Body will list the Docker tags pushed and a link to the Buildx release that has been used.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>